### PR TITLE
add link to github repo when publishing package

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,10 @@
 {
 	"name": "svelte-fuse-rx",
 	"version": "0.0.102",
+	"repository": {
+		"type": "git",
+		"url": "git+https://github.com/AlexWarnes/svelte-fuse-rx.git"
+	},
 	"scripts": {
 		"dev": "svelte-kit dev",
 		"build": "svelte-kit build",


### PR DESCRIPTION
this package source wasn't super straightforward to find from a project that was using it. this should help