### PR TITLE
Add file extensions for Node.js compatibility

### DIFF
--- a/src/lib/index.js
+++ b/src/lib/index.js
@@ -1,4 +1,4 @@
-import { rxWritable } from './rx';
+import { rxWritable } from './rx.js';
 import {
 	rxDebounce,
 	rxThrottle,
@@ -6,7 +6,7 @@ import {
 	rxBufferCount,
 	rxGet,
 	rxGETFromInput
-} from './rxActions';
+} from './rxActions.js';
 
 export {
 	rxDebounce,


### PR DESCRIPTION
This library cannot be consumed by Vite / SvelteKit. See https://github.com/sveltejs/kit/issues/4821#issuecomment-1118827059 and https://github.com/sveltejs/cli/issues/205